### PR TITLE
Add a wrapper for sendUsageEvents

### DIFF
--- a/src/components/core/MantleProvider/MantleProvider.js
+++ b/src/components/core/MantleProvider/MantleProvider.js
@@ -160,6 +160,7 @@ export const MantleProvider = ({
         loading,
         i18n: { ...Labels, ...i18n },
         sendUsageEvent,
+        sendUsageEvents,
         getUsageReport,
         subscribe,
         cancelSubscription,
@@ -221,6 +222,7 @@ export const useMantle = () => {
  * @property {boolean} loading - Whether the current customer is loading
  * @property {RefetchCallback} refetch - Refetch the current customer
  * @property {SendUsageEventCallback} sendUsageEvent - Send a new usage event to Mantle
+ * @property {SendUsageEventCallback} sendUsageEvents - Send a set of new usage event to Mantle
  * @property {GetUsageReportCallback} getUsageReport - Get a usage report for a usage metric
  * @property {SubscribeCallback} subscribe - Subscribe to a new plan
  * @property {CancelSubscriptionCallback} cancelSubscription - Cancel the current subscription

--- a/src/components/core/MantleProvider/MantleProvider.js
+++ b/src/components/core/MantleProvider/MantleProvider.js
@@ -71,6 +71,13 @@ export const MantleProvider = ({
   };
 
   /**
+  * @type {SendUsageEventCallback}
+  */
+  const sendUsageEvents = async (usageEvent) => {
+    await mantleClient.sendUsageEvents(usageEvent);
+  };
+
+  /**
    * @type {GetUsageReportCallback}
    */
   const getUsageReport = async ({ usageId, period }) => {


### PR DESCRIPTION
The bulk event send didnt seem to have incorporated. I wasn't sure if there's a reason to avoid but this actually is very useful to have.

Adding it as described here https://github.com/Hey-Mantle/mantle-client/blob/00a2f0be22e7f005b8bfc0567e45a609c50cd2b2/src/index.js#L231